### PR TITLE
feat: consolidate dependency updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-kubernetes==35.0.0
+kubernetes==36.0.1
 requests==2.34.2
 glueops-helpers @ https://github.com/GlueOps/python-glueops-helpers-library/archive/refs/tags/v0.6.0.zip


### PR DESCRIPTION
Consolidates the open Renovate dependency updates into one reviewable PR, validated in Docker.

## Included bumps
- **`kubernetes` 35.0.0 → 36.0.1** (major) — supersedes #177.

## Validation (in Docker, per GlueOps convention)
- `docker build .` (repo's own Dockerfile) succeeds — `pip install -r requirements.txt` resolves and installs `kubernetes-36.0.1` cleanly alongside `requests` and `glueops-helpers`.
- Import smoke test in the built image passes (`import kubernetes, serviceconfig`).

## Notes
- The `kubernetes` library is **not imported anywhere** in the source (`monitoring_script.py` / `serviceconfig.py` only read env vars and build URLs), so this major bump carries no API-break risk for the app — it only needs to install cleanly, which it does.
- Committed as `feat:` (release-triggering), not `chore(deps):`.

## Excluded
- None — this was the only open bot PR.